### PR TITLE
fix: lookbehind simplifies transformIgnorePatterns & ensures correctness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.DS_Store
 
 # NPM
-node_modules
+/node_modules
 npm-debug.log
 
 # Build

--- a/README.md
+++ b/README.md
@@ -131,16 +131,16 @@ In the above example config, any tests with `*.browser.js` will run in a JSDOM c
 
 ## Using tags from npm
 
-By default Jest will not transform any `.marko` files within your `node_modules` folder. Marko recommends publishing the original source Marko files when publishing to npm. To get around this you can use the [`transformIgnorePatterns`](https://jestjs.io/docs/en/tutorial-react-native#transformignorepatterns-customization) option in Jest and whitelist any packages which contain Marko tags.
+By default Jest will not transform any `.marko` files within your `node_modules` folder. Marko recommends publishing the original source Marko files when publishing to npm. To get around this you can use the [`transformIgnorePatterns`](https://jestjs.io/docs/en/tutorial-react-native#transformignorepatterns-customization) option in Jest and whitelist `.marko` files.
 
-The `@marko/jest` preset by will scan your `node_modules` and build the appropriate ignore pattern for you. If you are just using the `@marko/jest` transformer standalone then you will have to do this yourself, like so:
+The `@marko/jest` preset sets the ignore pattern for you. If you are just using the `@marko/jest` transformer standalone then you will have to do this yourself, like so:
 
 **jest.config.js**
 
 ```javascript
 module.exports = {
   ...,
-  transformIgnorePatterns: ["node_modules/(?!(marko|@marko-tags|another-package-with-marko-tags)/)"]
+  transformIgnorePatterns: ["node_modules/.*(?<!\\.marko)$"]
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ module.exports = {
   moduleFileExtensions: defaults.moduleFileExtensions.concat("marko"),
   // preprocesses Marko files.
   transform: { "\\.marko$": "@marko/jest" },
-  // transforms top level `.marko` files in the Marko package.
-  transformIgnorePatterns: ["node_modules/(?!(marko)/)"]
+  // transforms `.marko` files in node_modules as well
+  transformIgnorePatterns: ["node_modules/.*(?<!\\.marko)$"]
   browser: true
 };
 ```

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -1,11 +1,4 @@
-const fs = require("fs");
-const path = require("path");
 const { defaults } = require("jest-config");
-const escapeRegexp = require("escape-string-regexp");
-const { package, path: packagePath } = require("read-pkg-up").sync({
-  normalize: false
-});
-const nodeModulesPath = path.join(packagePath, "../node_modules");
 
 module.exports = {
   // uses a webpack style resolver, the default one has many issues.
@@ -18,18 +11,6 @@ module.exports = {
     "\\.[tj]s$": "babel-jest"
   },
   // Jest ignores node_module transforms by default.
-  // Here we whitelist all node_modules that contain a `marko.json`.
-  // Only checks for node_modules listed in package.json, same as Marko taglib scanning.
-  transformIgnorePatterns: [
-    `node_modules/(?!(${Object.keys(package.dependencies || {})
-      .concat(Object.keys(package.devDependencies || {}))
-      .concat(Object.keys(package.peerDependencies || {}))
-      .filter((name, i, all) => all.indexOf(name) === i)
-      .filter(name =>
-        fs.existsSync(path.join(nodeModulesPath, name, "marko.json"))
-      )
-      .map(escapeRegexp)
-      .concat("marko")
-      .join("|")})/)`
-  ]
+  // Here we whitelist all `.marko` files.
+  transformIgnorePatterns: ["node_modules/.*(?<!\\.marko)$"]
 };

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "bugs": "https://github.com/marko-js/jest/issues",
   "dependencies": {
     "enhanced-resolve-jest": "^1.0.2",
-    "escape-string-regexp": "^2.0.0",
     "jest-config": "^24.8.0",
-    "read-pkg-up": "^6.0.0",
     "tslib": "^1.10.0"
   },
   "devDependencies": {

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -1,5 +1,6 @@
 import Example from "./fixtures/example.marko";
 import Mockable from "./fixtures/mockable.marko";
+import Project from "./fixtures/project/index.marko";
 
 afterEach(() => {
   document.body.innerHTML = "";
@@ -19,5 +20,13 @@ test("can be mocked", async () => {
   result.appendTo(document.body).getComponent();
   expect(document.body.innerHTML).toMatchInlineSnapshot(
     `"<div>Hello Mocked</div>"`
+  );
+});
+
+test("transforms templates in node_modules", async () => {
+  const result = await Project.render({});
+  result.appendTo(document.body).getComponent();
+  expect(document.body.innerHTML).toMatchInlineSnapshot(
+    `"<div class=\\"direct\\"><div class=\\"indirect\\">Hello World</div></div>"`
   );
 });

--- a/test/fixtures/project/index.marko
+++ b/test/fixtures/project/index.marko
@@ -1,0 +1,3 @@
+<direct-tag>
+  Hello World
+</direct-tag>

--- a/test/fixtures/project/index.marko.d.ts
+++ b/test/fixtures/project/index.marko.d.ts
@@ -1,0 +1,2 @@
+declare let x: any;
+export = x;

--- a/test/fixtures/project/node_modules/direct/index.marko
+++ b/test/fixtures/project/node_modules/direct/index.marko
@@ -1,0 +1,5 @@
+<div.direct>
+  <indirect-tag>
+    <${input.renderBody}/>
+  </indirect-tag>
+</div>

--- a/test/fixtures/project/node_modules/direct/marko.json
+++ b/test/fixtures/project/node_modules/direct/marko.json
@@ -1,0 +1,5 @@
+{
+  "<direct-tag>": {
+    "template": "./index.marko"
+  }
+}

--- a/test/fixtures/project/node_modules/direct/node_modules/indirect/index.marko
+++ b/test/fixtures/project/node_modules/direct/node_modules/indirect/index.marko
@@ -1,0 +1,3 @@
+<div.indirect>
+  <${input.renderBody}/>
+</div>

--- a/test/fixtures/project/node_modules/direct/node_modules/indirect/marko.json
+++ b/test/fixtures/project/node_modules/direct/node_modules/indirect/marko.json
@@ -1,0 +1,5 @@
+{
+  "<indirect-tag>": {
+    "template": "./index.marko"
+  }
+}

--- a/test/fixtures/project/node_modules/direct/node_modules/indirect/package.json
+++ b/test/fixtures/project/node_modules/direct/node_modules/indirect/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "direct"
+}

--- a/test/fixtures/project/node_modules/direct/package.json
+++ b/test/fixtures/project/node_modules/direct/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "indirect",
+  "dependencies": {
+    "indirect": "*"
+  }
+}

--- a/test/fixtures/project/package.json
+++ b/test/fixtures/project/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "direct": "*"
+  }
+}

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,5 +1,6 @@
 import Example from "./fixtures/example.marko";
 import Mockable from "./fixtures/mockable.marko";
+import Project from "./fixtures/project/index.marko";
 
 test("server rendering", () => {
   expect(Example.renderSync({}).toString()).toMatchInlineSnapshot(
@@ -11,5 +12,11 @@ jest.mock("./fixtures/mockable.marko");
 test("can be mocked", async () => {
   expect(Mockable.renderSync({}).toString()).toMatchInlineSnapshot(
     `"<div>Hello Mocked</div>"`
+  );
+});
+
+test("transforms templates in node_modules", () => {
+  expect(Project.renderSync({}).toString()).toMatchInlineSnapshot(
+    `"<div class=\\"direct\\"><div class=\\"indirect\\">Hello World</div></div>"`
   );
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Uses a negative lookbehind regex for `transformIgnorePatterns` which ignores anything under `node_modules` that isn't a `.marko` file.  This fixes an issue where the old implementation (which only handled ignoring packages in your project's `package.json`) wouldn't transform `.marko` files in nested dependencies.

It's also a lot simpler than iterating over packages.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
