### PR TITLE
feat: add support for jest 26, log warnings with legacy configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@
 npm-debug.log
 
 # Build
-dist
+/transform
+/preset
 
 # Coverage
 coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,5 +5,6 @@ package-lock.json
 CHANGELOG.md
 node_modules
 coverage
-dist
+/preset
+/transform
 *.actual.*

--- a/README.md
+++ b/README.md
@@ -50,26 +50,24 @@ npm install @marko/jest -D
 
 ```javascript
 module.exports = {
-  preset: "@marko/jest",
-  browser: true
+  preset: "@marko/jest/preset/browser"
 };
 ```
 
-The above is equivalent to:
+The above is roughly equivalent to:
 
 ```javascript
 const { defaults } = require("jest-config");
 
 module.exports = {
-  // uses a webpack style resolver, the default one has many issues.
-  resolver: "enhanced-resolve-jest",
+  // uses a webpack style resolver
+  resolver: "...",
   // allows for stuff like file watching of `.marko` files
   moduleFileExtensions: defaults.moduleFileExtensions.concat("marko"),
   // preprocesses Marko files.
-  transform: { "\\.marko$": "@marko/jest" },
+  transform: { "\\.marko$": "@marko/jest/transform/browser" },
   // transforms `.marko` files in node_modules as well
-  transformIgnorePatterns: ["node_modules/.*(?<!\\.marko)$"]
-  browser: true
+  transformIgnorePatterns: ["node_modules/.*(?<!\\.marko)$"
 };
 ```
 
@@ -81,18 +79,17 @@ Jest presets are extensible by default, meaning you should be able to continue t
 
 ```javascript
 module.exports = {
-  preset: "@marko/jest",
+  preset: "@marko/jest/preset/browser",
   transform: {
     "\\.ts$": "ts-jest"
-  },
-  browser: true
+  }
 };
 ```
 
-You can also get access to the preset configuration manually by importing `@marko/jest/jest-preset` and use it like so:
+You can also get access to the preset configuration manually by importing `@marko/jest/preset/browser/jest-preset` and use it like so:
 
 ```javascript
-const markoJest = require("@marko/jest/jest-preset");
+const markoJest = require("@marko/jest/preset/browser/jest-preset");
 module.exports = {
   transform: markoJest.transform,
   transformIgnorePatterns: markoJest.transformIgnorePatterns,
@@ -104,7 +101,7 @@ module.exports = {
 
 ## Test both server & browser
 
-The above configurations all set `browser: true`, for many Marko projects you may have a mix of server and browser components. You can test all of these with Jest by using the [projects configuration](https://jestjs.io/docs/en/configuration#projects-array-string-projectconfig) [like this project does](./blob/master/jest.config.js)!
+For many Marko projects you may have a mix of server and browser components. You can test all of these with Jest by using the [projects configuration](https://jestjs.io/docs/en/configuration#projects-array-string-projectconfig) [like this project does](./blob/master/jest.config.js)! Simply make sure to use `@marko/jest/preset/node` and `@marko/jest/preset/browser` according to the test environment.
 
 **jest.config.js**
 
@@ -113,14 +110,12 @@ module.exports = {
   projects: [
     {
       displayName: "browser",
-      preset: "@marko/jest",
-      browser: true,
+      preset: "@marko/jest/preset/browser",
       testMatch: ["**/__tests__/**/*.browser.js"]
     },
     {
       displayName: "server",
-      preset: "@marko/jest",
-      testEnvironment: "node",
+      preset: "@marko/jest/preset/node",
       testMatch: ["**/__tests__/**/*.server.js"]
     }
   ]
@@ -133,7 +128,7 @@ In the above example config, any tests with `*.browser.js` will run in a JSDOM c
 
 By default Jest will not transform any `.marko` files within your `node_modules` folder. Marko recommends publishing the original source Marko files when publishing to npm. To get around this you can use the [`transformIgnorePatterns`](https://jestjs.io/docs/en/tutorial-react-native#transformignorepatterns-customization) option in Jest and whitelist `.marko` files.
 
-The `@marko/jest` preset sets the ignore pattern for you. If you are just using the `@marko/jest` transformer standalone then you will have to do this yourself, like so:
+The `@marko/jest/preset/*` helpers set the ignore pattern for you. If you are using the `@marko/jest/transform/*` directly then you will have to do this yourself, like so:
 
 **jest.config.js**
 

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -1,4 +1,13 @@
 const { defaults } = require("jest-config");
+const { version } = require("jest/package.json");
+const warning =
+  "@marko/jest preset will not work with jest@26 and above. Instead use @marko/jest/preset/browser or @marko/jest/preset/node.";
+
+if (parseInt(version.split(".")[0], 10) >= 26) {
+  throw new Error(warning);
+} else {
+  console.warn(warning);
+}
 
 module.exports = {
   // uses a webpack style resolver, the default one has many issues.
@@ -7,7 +16,7 @@ module.exports = {
   moduleFileExtensions: defaults.moduleFileExtensions.concat("marko"),
   // preprocesses Marko files.
   transform: {
-    "\\.marko$": require.resolve("."),
+    "\\.marko$": require.resolve("./transform/node"),
     "\\.[tj]s$": "babel-jest"
   },
   // Jest ignores node_module transforms by default.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,4 @@
 const base = {
-  preset: "./jest-preset",
   transform: {
     "\\.ts$": "ts-jest",
     "\\.css$": "jest-transform-css"
@@ -10,14 +9,15 @@ module.exports = {
   projects: [
     {
       ...base,
-      displayName: "server",
+      preset: "./preset/node/jest-preset.js",
+      displayName: "node",
       testEnvironment: "node",
       testMatch: ["<rootDir>/test/server.test.ts"]
     },
     {
       ...base,
+      preset: "./preset/browser/jest-preset.js",
       displayName: "browser",
-      browser: true,
       testMatch: ["<rootDir>/test/browser.test.ts"]
     }
   ]

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "typescript": "^3.5.3"
   },
   "files": [
-    "dist",
+    "preset",
+    "transform",
     "jest-preset.js"
   ],
   "homepage": "https://github.com/marko-js/jest",
@@ -42,7 +43,7 @@
     "test"
   ],
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "transform/node.js",
   "peerDependencies": {
     "marko": "^3 || ^4"
   },

--- a/src/preset/browser/jest-preset.ts
+++ b/src/preset/browser/jest-preset.ts
@@ -1,0 +1,12 @@
+import sharedPreset from "../shared-preset";
+
+export = {
+  ...sharedPreset,
+  // uses a webpack style resolver, the default one has many issues.
+  resolver: require.resolve("./resolver"),
+  // preprocesses Marko files.
+  transform: {
+    "\\.marko$": require.resolve("../../transform/browser"),
+    ...sharedPreset.transform
+  }
+};

--- a/src/preset/browser/resolver.ts
+++ b/src/preset/browser/resolver.ts
@@ -1,0 +1,8 @@
+import { create, getDefaultConfig } from "enhanced-resolve-jest";
+
+export = create(jestConfig => {
+  const baseConfig = getDefaultConfig(jestConfig);
+  baseConfig.aliasFields = ["browser"];
+  baseConfig.mainFields = ["browser", "main"];
+  return baseConfig;
+});

--- a/src/preset/node/jest-preset.ts
+++ b/src/preset/node/jest-preset.ts
@@ -1,0 +1,12 @@
+import sharedPreset from "../shared-preset";
+
+export = {
+  ...sharedPreset,
+  // avoid loading jsdom.
+  testEnvironment: "node",
+  // preprocesses Marko files.
+  transform: {
+    "\\.marko$": require.resolve("../../transform/node"),
+    ...sharedPreset.transform
+  }
+};

--- a/src/preset/shared-preset.ts
+++ b/src/preset/shared-preset.ts
@@ -1,0 +1,10 @@
+import { defaults } from "jest-config";
+
+export = {
+  // allows for stuff like file watching of `.marko` files
+  moduleFileExtensions: defaults.moduleFileExtensions.concat("marko"),
+  transform: { "\\.[tj]s$": "babel-jest" },
+  // Jest ignores node_module transforms by default.
+  // Here we whitelist all `.marko` files.
+  transformIgnorePatterns: ["node_modules/.*(?<!\\.marko)$"]
+};

--- a/src/transform/browser.ts
+++ b/src/transform/browser.ts
@@ -1,0 +1,2 @@
+import createTransform from "./create-transform";
+export = createTransform({ browser: true });

--- a/src/transform/create-transform.ts
+++ b/src/transform/create-transform.ts
@@ -6,7 +6,7 @@ import ConcatMap from "concat-with-sourcemaps";
 import { Transformer } from "@jest/transform";
 const THIS_FILE = fs.readFileSync(__filename);
 
-export = {
+export = ({ browser }: { browser: boolean }) => ({
   getCacheKey(fileData, filename, configString, { instrument, rootDir }) {
     return crypto
       .createHash("md5")
@@ -25,7 +25,7 @@ export = {
   },
   process(src, filename, config) {
     const result = compiler[
-      config.browser &&
+      (browser || config.browser) &&
       compiler.compileForBrowser /** Only Marko 4 supports compileForBrowser, otherwise use compile */
         ? "compileForBrowser"
         : "compile"
@@ -98,4 +98,4 @@ export = {
     };
   },
   canInstrument: false
-} as Transformer;
+} as Transformer);

--- a/src/transform/node.ts
+++ b/src/transform/node.ts
@@ -1,0 +1,2 @@
+import createTransform from "./create-transform";
+export = createTransform({ browser: false });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "lib": ["dom", "es2015", "scripthost"],
     "pretty": true,
     "target": "es5",
-    "outDir": "./dist",
+    "outDir": ".",
     "sourceMap": true,
     "declaration": true,
     "stripInternal": true,
@@ -14,5 +14,6 @@
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*"],
+  "exclude": []
 }


### PR DESCRIPTION
## Description

Jest broke us https://github.com/facebook/jest/issues/10036. Specifically our reliance on the `browser` option jest used which allowed us to have a common preset which could target both server and browser compilations and module resolution.

The only way for us to support `jest@26` and above is to split these into two presets and transformers.

The new top level api is:

```
preset: "@marko/jest/preset/browser"
```

for jsdom support and

```
preset: "@marko/jest/preset/node"
```

for testing server side components in the node environment.

Like wise the `transform` has been split into two and can be accessed via `@marko/jest/transform/node` and `@marko/jest/transform/browser`.

The default preset has been left in this release but now logs a warning if you are below jest 25 and throws is you are on jest 26.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
