### PR TITLE
Support Jest 28

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "license": "MIT",
   "main": "transform/node.js",
   "peerDependencies": {
-    "jest-config": "23 - 27"
+    "jest-config": "23 - 28"
   },
   "repository": {
     "type": "git",

--- a/src/transform/create-transform.ts
+++ b/src/transform/create-transform.ts
@@ -155,7 +155,7 @@ export default ({ browser }: { browser: boolean }) => {
         ).toString("base64")}`;
       }
 
-      return code;
+      return { code };
     },
   };
 


### PR DESCRIPTION
## Description

Support Jest 28

## Motivation and Context

Jest 28 requires `process()` to always [return an object](https://jestjs.io/docs/upgrading-to-jest28#transformer)

This certainly works for Jest 27 and 28, but I can't tell if I've broken earlier versions. Alternately, I don't know how to detect the current version of Jest and change the output accordingly in order to support older versions.